### PR TITLE
--fix(layout):: make header and sidebar fixed, main content scrollable

### DIFF
--- a/src/Component/Shared/Layout.jsx
+++ b/src/Component/Shared/Layout.jsx
@@ -3,8 +3,8 @@ import SideBar from "../SideBar";
 
 const Layout = ({ children }) => {
   return (
-    <section className="mx-auto max-w-screen-2xl">
-      <div className="grid grid-cols-[15rem_1fr] grid-rows-[5rem_1fr] h-screen">
+    <section className="mx-auto max-w-screen-2xl h-screen">
+      <div className="grid grid-cols-[15rem_1fr] grid-rows-[5rem_1fr]">
         <SideBar />
 
         {/* this is the side bar  */}
@@ -12,7 +12,7 @@ const Layout = ({ children }) => {
         {/* nav will be here */}
         <Header />
 
-        <main className="col-start-2 col-end-3 row-start-2 row-end-3">
+        <main className="col-start-2 col-end-3 row-start-2 row-end-3 overflow-y-auto">
           {children}
         </main>
       </div>

--- a/src/Component/SideBar.jsx
+++ b/src/Component/SideBar.jsx
@@ -18,7 +18,7 @@ import { sereneSign } from '@/assets';
 
  export function SideBar() {
    return (
-     <aside className="hidden  md:block bg-[#272727] text-serene-ash serene-sidebar sticky top-0 z-[1000] col-start-1 col-end-2 row-span-3">
+     <aside className="hidden  md:block bg-[#272727] text-serene-ash serene-sidebar sticky top-0 z-[1000] col-start-1 col-end-2 row-span-3 h-screen">
        <div className="flex h-full max-h-screen flex-col gap-2">
          <div className=" flex flex-col gap-11 border-b-[0.1rem] border-[#575757] py-6 pb-32 lg:h-[60px] lg:px-6">
            <a href="/" className="flex items-center gap-2 font-semibold ">


### PR DESCRIPTION
- Adjusted the app layout to ensure the header and sidebar remain fixed when scrolling
- Enabled scrolling for the main content area.